### PR TITLE
Better shebang portability

### DIFF
--- a/measure-dns-nsid.py
+++ b/measure-dns-nsid.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """ Python code to start a RIPE Atlas UDM (User-Defined
 Measurement). This one is for running DNS NSID queries (find the


### PR DESCRIPTION
Use env(1) to locate shell binary (see http://en.wikipedia.org/wiki/Shebang_%28Unix%29#Portability) - so it would work fine in FreeBSD and other systems with python binary placed not at /usr/bin/, but somewhere other.
