### PR TITLE
add ripeatlas probe geoselect as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ripeatlas-probe-geoselect"]
+	path = ripeatlas-probe-geoselect
+	url = https://github.com/emileaben/ripeatlas-probe-geoselect.git


### PR DESCRIPTION
I've added script + documentation for the ripeatlas probe selection based on geolocation tool as a submodule.