### PR TITLE
Fix the path to the 'latest' measurements. 

### DIFF
--- a/RIPEAtlas.py
+++ b/RIPEAtlas.py
@@ -110,7 +110,7 @@ class Measurement():
         self.url_status = base_url + "/%s/?fields=status" 
         self.url_results = base_url + "/%s/results/"
         self.url_all = base_url + "/%s/" 
-        self.url_latest = base_url + "-latest/%s/?versions=%s"
+        self.url_latest = base_url + "/%s/latest/?versions=%s"
 
         self.status = None
         
@@ -216,6 +216,8 @@ class Measurement():
         """
         if latest is not None:
             wait = False
+            if latest < 1 or latest > 10:
+                raise IncompatibleArguments("Latest can only be a value between 1 and 10. %s is out of that range." % latest)
         if latest is None:
             request = JsonRequest(self.url_results % self.id)
         else:


### PR DESCRIPTION
Also value check the passed argument to ensure it is in the documented range (1-10).

The first reference path is /api/v2/measurements/<id>/latest. This is tested and works.

The second reference path is /api/v2/measurement-latest/<id>/. This returns a 404. As does the potential typo-fixed /api/v2/measurements-latest/<id>/.

Reference document: https://atlas.ripe.net/docs/api/v2/manual/measurements/latest.html